### PR TITLE
Allow scalpel-core version 0.6

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -9,7 +9,7 @@ packages:
 - '.'
 # Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
 extra-deps:
-- scalpel-core-0.5.0
+- scalpel-core-0.6.0
 
 # Override default flag values for local packages and extra-deps
 flags: {}

--- a/wikicfp-scraper.cabal
+++ b/wikicfp-scraper.cabal
@@ -20,13 +20,13 @@ library
   -- default-extensions:
   other-extensions:     OverloadedStrings, CPP
   exposed-modules:      Web.WikiCFP.Scraper
-                        
+
   other-modules:        Web.WikiCFP.Scraper.Type,
                         Web.WikiCFP.Scraper.Scalpel
   build-depends:        base >=4.6.0 && <5.0,
                         bytestring >=0.10.0 && <0.11,
                         text >=0.11.3.1 && <1.3,
-                        scalpel-core >=0.5.0 && <0.6,
+                        scalpel-core >=0.5.0 && <0.7,
                         time >=1.4.0 && <1.9,
                         attoparsec >=0.10.4 && <0.14
 
@@ -35,8 +35,8 @@ library
 --   hs-source-dirs:       app
 --   main-is:              Main.hs
 --   ghc-options:          -Wall -fno-warn-unused-imports
---   -- other-modules:       
---   -- other-extensions:    
+--   -- other-modules:
+--   -- other-extensions:
 --   build-depends:        base
 
 test-suite spec


### PR DESCRIPTION
This is needed to resolve commercialhaskell/stackage#4381